### PR TITLE
CLOUD-46: Fix 'exit 1' on replset-init of restarted CR w/existing PVC data

### DIFF
--- a/controller/replset/initiator_test.go
+++ b/controller/replset/initiator_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/percona/mongodb-orchestration-tools/internal/logger"
 	"github.com/percona/mongodb-orchestration-tools/internal/testutils"
 	"github.com/stretchr/testify/assert"
+	rsConfig "github.com/timvaillancourt/go-mongodb-replset/config"
 	"gopkg.in/mgo.v2"
 )
 
@@ -96,4 +97,23 @@ func TestControllerReplsetInitiatorInitUsers(t *testing.T) {
 	users := user.SystemUsers()
 	assert.Len(t, users, 1)
 	assert.NoError(t, user.RemoveUser(testSession, users[0].Username, "admin"))
+}
+
+func TestControllerReplsetInitiatorInitReplset(t *testing.T) {
+	testutils.DoSkipTest(t)
+
+	// load replset config from session
+	i := &Initiator{}
+	rsCnfMan := rsConfig.New(testSession)
+	err := rsCnfMan.Load()
+	if err != nil {
+		t.Fatalf("Failed to get replset config: %v", err)
+	}
+
+	// test initReplset() returns error ErrReplsetInitiated if the replset
+	// is already initiated. The test replset is initiated before running
+	// tests so this will always return ErrReplsetInitiated.
+	//
+	// https://jira.percona.com/browse/CLOUD-46
+	assert.Equal(t, i.initReplset(rsCnfMan), ErrReplsetInitiated)
 }


### PR DESCRIPTION
This fixes a problem where the operator fails to initiate a replset that was already initiated before CR creation time. We should skip and exit 0, but instead we exit 1 with a "not master" error.

The fix ensures the replset config is loaded from the session before .IsInitiated() is called to check if the replset was already initiated here: https://github.com/percona/mongodb-orchestration-tools/blob/9068d0e9a67402e520a683a323b6c0800042ba4f/controller/replset/initiator.go#L60-L62
Without this PR this ^^^ block is getting skipped.