### PR TITLE
Do not use .Load() to get replsetConfig on non-auth session to fix error

### DIFF
--- a/controller/replset/initiator.go
+++ b/controller/replset/initiator.go
@@ -75,7 +75,7 @@ func (i *Initiator) initReplset(rsCnfMan rsConfig.Manager) error {
 				"version": config.Version,
 			}).Info("Initiated replset with config:")
 			break
-		} else if isError(err, ErrMsgDNSNotReady) {
+		} else if !isError(err, ErrMsgDNSNotReady) {
 			log.WithFields(log.Fields{
 				"replset": i.config.Replset,
 				"error":   err,

--- a/controller/replset/initiator.go
+++ b/controller/replset/initiator.go
@@ -31,11 +31,11 @@ import (
 const (
 	ErrMsgDNSNotReady         = "No host described in new configuration 1 for replica set rs maps to this node"
 	ErrMsgNotAuthorizedPrefix = "not authorized on admin to execute command"
+	ErrMsgNotPrimary          = "not primary"
 )
 
 var (
 	ErrCannotInitReplset = errors.New("could not init replset")
-	ErrReplsetInitiated  = errors.New("replset initiated")
 )
 
 type Initiator struct {
@@ -49,18 +49,14 @@ func NewInitiator(config *controller.Config) *Initiator {
 	}
 }
 
-func isNotAuthorizedError(err error) bool {
+func isError(err error, prefix string) bool {
 	if err != nil {
-		return strings.HasPrefix(err.Error(), ErrMsgNotAuthorizedPrefix)
+		return strings.HasPrefix(err.Error(), prefix)
 	}
 	return false
 }
 
 func (i *Initiator) initReplset(rsCnfMan rsConfig.Manager) error {
-	if rsCnfMan.IsInitiated() {
-		return ErrReplsetInitiated
-	}
-
 	config := rsConfig.NewConfig(i.config.Replset)
 	member := rsConfig.NewMember(i.config.ReplsetInit.PrimaryAddr)
 	member.Tags = &rsConfig.ReplsetTags{
@@ -79,10 +75,7 @@ func (i *Initiator) initReplset(rsCnfMan rsConfig.Manager) error {
 				"version": config.Version,
 			}).Info("Initiated replset with config:")
 			break
-		} else if isNotAuthorizedError(err) {
-			log.Info("Got mongodb auth error, server appears to be initiated already. Skipping")
-			return ErrReplsetInitiated
-		} else if err.Error() != ErrMsgDNSNotReady {
+		} else if isError(err, ErrMsgDNSNotReady) {
 			log.WithFields(log.Fields{
 				"replset": i.config.Replset,
 				"error":   err,
@@ -100,7 +93,7 @@ func (i *Initiator) initReplset(rsCnfMan rsConfig.Manager) error {
 
 func (i *Initiator) initAdminUser(session *mgo.Session) error {
 	err := user.UpdateUser(session, user.UserAdmin, "admin")
-	if err != nil && !isNotAuthorizedError(err) {
+	if err != nil && !isError(err, ErrMsgNotAuthorizedPrefix) {
 		return err
 	}
 	return nil
@@ -189,23 +182,10 @@ func (i *Initiator) getReplsetSession() (*mgo.Session, error) {
 }
 
 func (i *Initiator) prepareReplset(session *mgo.Session) error {
-	// load replset config from session
-	rsCnfMan := rsConfig.New(session)
-	err := rsCnfMan.Load()
+	err := i.initReplset(rsConfig.New(session))
 	if err != nil {
-		log.WithError(err).Error("Error loading replset config")
+		log.WithError(err).Error("Error intiating replica set")
 		return err
-	}
-
-	// init replset
-	err = i.initReplset(rsCnfMan)
-	if err != nil {
-		if err == ErrReplsetInitiated {
-			log.Warning("Replset already initiated, skipping")
-		} else {
-			log.WithError(err).Error("Error intiating replica set")
-			return err
-		}
 	} else {
 		log.Info("Waiting for host to become primary")
 		err = db.WaitForPrimary(session, i.config.ReplsetInit.MaxConnectTries, i.config.ReplsetInit.RetrySleep)
@@ -244,6 +224,10 @@ func (i *Initiator) Run() error {
 
 	err = i.prepareReplset(localhostNoAuthSession)
 	if err != nil {
+		if isError(err, ErrMsgNotAuthorizedPrefix) || isError(err, ErrMsgNotPrimary) {
+			log.Warning("Replset already initiated, skipping initiation")
+			return nil
+		}
 		log.WithError(err).Error("Error preparing replset")
 		return err
 	}


### PR DESCRIPTION
Fixes access-denied error on new replica sets with clean PVC, due to merge of https://github.com/percona/mongodb-orchestration-tools/pull/226