### PR TITLE
Don't bind test-mongods to all IPs, only 127.0.0.1 needed because of --network=host mode

### DIFF
--- a/docker/test/entrypoint.sh
+++ b/docker/test/entrypoint.sh
@@ -7,7 +7,7 @@ cp /rootCA.crt /tmp/mongod-rootCA.crt
 chmod 600 /tmp/mongod.key /tmp/mongod.pem /tmp/mongod-rootCA.crt
 
 /usr/bin/mongod \
-	--bind_ip=0.0.0.0 \
+	--bind_ip=127.0.0.1 \
 	--replSet=${TEST_RS_NAME:-rs} \
 	--keyFile=/tmp/mongod.key \
 	--sslMode=preferSSL \


### PR DESCRIPTION
Low-priority fix for a small misconfiguration I noticed. The unit-test replset launched by docker-compose should only bind to localhost, not all IPs (for security)