### PR TITLE
CLOUD-76: Support multi-CRs in 'k8s' watchdog pod source

### DIFF
--- a/pkg/pod/k8s/pods.go
+++ b/pkg/pod/k8s/pods.go
@@ -30,25 +30,6 @@ const (
 	EnvKubernetesPort = "KUBERNETES_SERVICE_PORT"
 )
 
-func NewPods(serviceName, namespace string) *Pods {
-	return &Pods{
-		namespace:    namespace,
-		serviceName:  serviceName,
-		pods:         make([]corev1.Pod, 0),
-		statefulsets: make([]appsv1.StatefulSet, 0),
-		services:     make([]corev1.Service, 0),
-	}
-}
-
-type Pods struct {
-	sync.Mutex
-	namespace    string
-	serviceName  string
-	pods         []corev1.Pod
-	statefulsets []appsv1.StatefulSet
-	services     []corev1.Service
-}
-
 func getPodReplsetName(pod *corev1.Pod) (string, error) {
 	for _, container := range pod.Spec.Containers {
 		for _, env := range container.Env {
@@ -58,6 +39,54 @@ func getPodReplsetName(pod *corev1.Pod) (string, error) {
 		}
 	}
 	return "", errors.New("could not find mongodb replset name")
+}
+
+// CustomResourceState represents the state of a single
+// Kubernetes CR for PSMDB
+type CustomResourceState struct {
+	Name         string
+	pods         []corev1.Pod
+	services     []corev1.Service
+	statefulsets []appsv1.StatefulSet
+}
+
+func (cr *CustomResourceState) getServiceFromPod(pod *corev1.Pod) *corev1.Service {
+	serviceName := pod.Name
+	for i, svc := range cr.services {
+		if svc.Name != serviceName {
+			continue
+		}
+		return &cr.services[i]
+	}
+	return nil
+}
+
+func (cr *CustomResourceState) getStatefulSetFromPod(pod *corev1.Pod) *appsv1.StatefulSet {
+	replsetName, err := getPodReplsetName(pod)
+	if err != nil {
+		return nil
+	}
+	setServiceName := cr.Name + "-" + replsetName
+	for i, statefulset := range cr.statefulsets {
+		if statefulset.Spec.ServiceName != setServiceName {
+			continue
+		}
+		return &cr.statefulsets[i]
+	}
+	return nil
+}
+
+func NewPods(namespace string) *Pods {
+	return &Pods{
+		namespace: namespace,
+		crs:       make(map[string]*CustomResourceState),
+	}
+}
+
+type Pods struct {
+	sync.Mutex
+	namespace string
+	crs       map[string]*CustomResourceState
 }
 
 func (p *Pods) Name() string {
@@ -73,68 +102,44 @@ func (p *Pods) URL() string {
 	return "tcp://" + host + ":" + port
 }
 
-func (p *Pods) Update(pods []corev1.Pod, statefulsets []appsv1.StatefulSet, services []corev1.Service) {
+// Update updates the state of a single PSMDB CR
+func (p *Pods) Update(crState *CustomResourceState) {
 	p.Lock()
 	defer p.Unlock()
-	p.pods = pods
-	p.statefulsets = statefulsets
-	p.services = services
+	p.crs[crState.Name] = crState
 }
 
+// Pods returns all available pod names
 func (p *Pods) Pods() ([]string, error) {
 	p.Lock()
 	defer p.Unlock()
 
 	pods := make([]string, 0)
-	for _, pod := range p.pods {
-		if pod.Status.Phase != corev1.PodRunning && pod.Status.Phase != corev1.PodPending {
-			continue
+	for _, cr := range p.crs {
+		for _, pod := range cr.pods {
+			if pod.Status.Phase != corev1.PodRunning && pod.Status.Phase != corev1.PodPending {
+				continue
+			}
+			pods = append(pods, pod.Name)
 		}
-		pods = append(pods, pod.Name)
 	}
 	return pods, nil
 }
 
-func (p *Pods) getStatefulSetFromPod(pod *corev1.Pod) *appsv1.StatefulSet {
-	replsetName, err := getPodReplsetName(pod)
-	if err != nil {
-		return nil
-	}
-	setServiceName := p.serviceName + "-" + replsetName
-	for i, statefulset := range p.statefulsets {
-		if statefulset.Spec.ServiceName != setServiceName {
-			continue
-		}
-		return &p.statefulsets[i]
-	}
-	return nil
-}
-
-func (p *Pods) getServiceFromPod(pod *corev1.Pod) *corev1.Service {
-	serviceName := pod.Name
-	for i, svc := range p.services {
-		if svc.Name != serviceName {
-			continue
-		}
-		return &p.services[i]
-	}
-	return nil
-}
-
+// GetTasks returns tasks for a single pod by name
 func (p *Pods) GetTasks(podName string) ([]pod.Task, error) {
 	p.Lock()
 	defer p.Unlock()
 
 	tasks := make([]pod.Task, 0)
-	for i := range p.pods {
-		pod := &p.pods[i]
-		if pod.Name != podName {
-			continue
+	for _, cr := range p.crs {
+		for i := range cr.pods {
+			pod := &cr.pods[i]
+			if pod.Name != podName {
+				continue
+			}
+			tasks = append(tasks, NewTask(p.namespace, cr, pod)) //, cr.getStatefulSetFromPod(pod), cr.getServiceFromPod(pod), cr.Name, p.namespace),
 		}
-		tasks = append(
-			tasks,
-			NewTask(pod, p.getStatefulSetFromPod(pod), p.getServiceFromPod(pod), p.serviceName, p.namespace),
-		)
 	}
 	return tasks, nil
 }

--- a/pkg/pod/k8s/pods.go
+++ b/pkg/pod/k8s/pods.go
@@ -138,7 +138,7 @@ func (p *Pods) GetTasks(podName string) ([]pod.Task, error) {
 			if pod.Name != podName {
 				continue
 			}
-			tasks = append(tasks, NewTask(p.namespace, cr, pod)) //, cr.getStatefulSetFromPod(pod), cr.getServiceFromPod(pod), cr.Name, p.namespace),
+			tasks = append(tasks, NewTask(p.namespace, cr, pod))
 		}
 	}
 	return tasks, nil

--- a/pkg/pod/k8s/pods.go
+++ b/pkg/pod/k8s/pods.go
@@ -102,6 +102,13 @@ func (p *Pods) URL() string {
 	return "tcp://" + host + ":" + port
 }
 
+// Delete deletes the state of a single PSMDB CR
+func (p *Pods) Delete(crState *CustomResourceState) {
+	p.Lock()
+	defer p.Unlock()
+	delete(p.crs, crState.Name)
+}
+
 // Update updates the state of a single PSMDB CR
 func (p *Pods) Update(crState *CustomResourceState) {
 	p.Lock()

--- a/pkg/pod/k8s/pods_test.go
+++ b/pkg/pod/k8s/pods_test.go
@@ -157,6 +157,13 @@ func TestInternalPodK8SPods(t *testing.T) {
 	assert.NotNil(t, addr)
 	assert.Equal(t, "TestInternalPodK8SPods-1.test-cluster1-rs.psmdb.svc.cluster.local:27017", addr.String())
 
+	// test .Delete() of CR
+	p2.Delete(&CustomResourceState{
+		Name: "test-cluster2",
+	})
+	pods, _ = p2.Pods()
+	assert.Len(t, pods, 1, "expected 1 pods after delete of 2nd CR")
+
 	// test Succeeded pod is not listed by .Pods()
 	corev1Pods[1].Status.Phase = corev1.PodSucceeded
 	p.Update(&CustomResourceState{

--- a/pkg/pod/k8s/pods_test.go
+++ b/pkg/pod/k8s/pods_test.go
@@ -29,14 +29,14 @@ import (
 func TestInternalPodK8SPods(t *testing.T) {
 	assert.Implements(t, (*pod.Source)(nil), &Pods{})
 
-	p := NewPods(pkg.DefaultServiceName, DefaultNamespace)
+	p := NewPods(DefaultNamespace)
 	assert.NotNil(t, p)
 
 	pods, err := p.Pods()
 	assert.NoError(t, err)
 	assert.Len(t, pods, 0)
 
-	corev1Pod := []corev1.Pod{
+	corev1Pods := []corev1.Pod{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "not-" + t.Name(),
@@ -81,7 +81,12 @@ func TestInternalPodK8SPods(t *testing.T) {
 			},
 		},
 	}
-	p.Update(corev1Pod, statefulsets, nil)
+
+	p.Update(&CustomResourceState{
+		Name:         "test-cluster",
+		pods:         corev1Pods,
+		statefulsets: statefulsets,
+	})
 	pods, _ = p.Pods()
 	assert.Len(t, pods, 1)
 	assert.Equal(t, t.Name(), pods[0])
@@ -92,8 +97,11 @@ func TestInternalPodK8SPods(t *testing.T) {
 	assert.Len(t, tasks, 1)
 
 	// test Succeeded pod is not listed by .Pods()
-	corev1Pod[1].Status.Phase = corev1.PodSucceeded
-	p.Update(corev1Pod, nil, nil)
+	corev1Pods[1].Status.Phase = corev1.PodSucceeded
+	p.Update(&CustomResourceState{
+		Name: "test-clusteR",
+		pods: corev1Pods,
+	})
 	pods, _ = p.Pods()
 	assert.Len(t, pods, 0)
 

--- a/pkg/pod/k8s/pods_test.go
+++ b/pkg/pod/k8s/pods_test.go
@@ -91,6 +91,37 @@ func TestInternalPodK8SPods(t *testing.T) {
 	assert.Len(t, pods, 1)
 	assert.Equal(t, t.Name(), pods[0])
 
+	// test several PSMDB CRs (https://jira.percona.com/browse/CLOUD-76)
+	p2 := NewPods(DefaultNamespace)
+	p2.Update(&CustomResourceState{
+		Name: "test-cluster1",
+		pods: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: t.Name() + "-1",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+		},
+	})
+	p2.Update(&CustomResourceState{
+		Name: "test-cluster2",
+		pods: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: t.Name() + "-2",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+		},
+	})
+	pods, _ = p2.Pods()
+	assert.Len(t, pods, 2, "expected 2 pods (1 pod per updated CR)")
+
 	// test .GetTasks()
 	tasks, err := p.GetTasks(t.Name())
 	assert.NoError(t, err)
@@ -99,7 +130,7 @@ func TestInternalPodK8SPods(t *testing.T) {
 	// test Succeeded pod is not listed by .Pods()
 	corev1Pods[1].Status.Phase = corev1.PodSucceeded
 	p.Update(&CustomResourceState{
-		Name: "test-clusteR",
+		Name: "test-cluster",
 		pods: corev1Pods,
 	})
 	pods, _ = p.Pods()

--- a/pkg/pod/k8s/task.go
+++ b/pkg/pod/k8s/task.go
@@ -16,12 +16,11 @@ package k8s
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
-	"fmt"
 	"github.com/percona/mongodb-orchestration-tools/pkg/db"
 	"github.com/percona/mongodb-orchestration-tools/pkg/pod"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -51,20 +50,16 @@ func (ts TaskState) String() string {
 }
 
 type Task struct {
-	pod         *corev1.Pod
-	statefulset *appsv1.StatefulSet
-	service     *corev1.Service
-	serviceName string
-	namespace   string
+	pod       *corev1.Pod
+	namespace string
+	cr        *CustomResourceState
 }
 
-func NewTask(pod *corev1.Pod, statefulset *appsv1.StatefulSet, service *corev1.Service, serviceName, namespace string) *Task {
+func NewTask(namespace string, cr *CustomResourceState, pod *corev1.Pod) *Task {
 	return &Task{
-		pod:         pod,
-		statefulset: statefulset,
-		service:     service,
-		namespace:   namespace,
-		serviceName: serviceName,
+		pod:       pod,
+		namespace: namespace,
+		cr:        cr,
 	}
 }
 
@@ -93,10 +88,11 @@ func (t *Task) IsRunning() bool {
 }
 
 func (t *Task) IsUpdating() bool {
-	if t.statefulset == nil {
+	statefulset := t.cr.getStatefulSetFromPod(t.pod)
+	if statefulset == nil {
 		return false
 	}
-	status := t.statefulset.Status
+	status := statefulset.Status
 	if status.CurrentRevision != status.UpdateRevision {
 		return true
 	}
@@ -126,7 +122,8 @@ func (t *Task) IsTaskType(taskType pod.TaskType) bool {
 }
 
 func (t *Task) GetMongoAddr() (*db.Addr, error) {
-	if t.service != nil {
+	service := t.cr.getServiceFromPod(t.pod)
+	if service != nil {
 		addr, err := t.getServiceAddr()
 		if err != nil {
 			return nil, err
@@ -144,7 +141,7 @@ func (t *Task) GetMongoAddr() (*db.Addr, error) {
 				return nil, err
 			}
 			addr := &db.Addr{
-				Host: GetMongoHost(t.pod.Name, t.serviceName, replset, t.namespace),
+				Host: GetMongoHost(t.pod.Name, t.cr.Name, replset, t.namespace),
 				Port: int(port.HostPort),
 			}
 			if addr.Port == 0 {
@@ -162,10 +159,12 @@ func (t *Task) GetMongoReplsetName() (string, error) {
 
 func (t *Task) getServiceAddr() (*db.Addr, error) {
 	addr := &db.Addr{}
-	switch t.service.Spec.Type {
+	service := t.cr.getServiceFromPod(t.pod)
+
+	switch service.Spec.Type {
 	case corev1.ServiceTypeClusterIP:
-		addr.Host = t.service.Spec.ClusterIP
-		for _, p := range t.service.Spec.Ports {
+		addr.Host = service.Spec.ClusterIP
+		for _, p := range service.Spec.Ports {
 			if p.Name != mongodbPortName {
 				continue
 			}
@@ -174,8 +173,8 @@ func (t *Task) getServiceAddr() (*db.Addr, error) {
 		return addr, nil
 
 	case corev1.ServiceTypeLoadBalancer:
-		addr.Host = t.service.Spec.LoadBalancerIP
-		for _, p := range t.service.Spec.Ports {
+		addr.Host = service.Spec.LoadBalancerIP
+		for _, p := range service.Spec.Ports {
 			if p.Name != mongodbPortName {
 				continue
 			}
@@ -185,7 +184,7 @@ func (t *Task) getServiceAddr() (*db.Addr, error) {
 
 	case corev1.ServiceTypeNodePort:
 		addr.Host = t.pod.Status.HostIP
-		for _, p := range t.service.Spec.Ports {
+		for _, p := range service.Spec.Ports {
 			if p.Name != mongodbPortName {
 				continue
 			}

--- a/pkg/pod/k8s/task.go
+++ b/pkg/pod/k8s/task.go
@@ -50,15 +50,15 @@ func (ts TaskState) String() string {
 }
 
 type Task struct {
-	pod       *corev1.Pod
 	namespace string
+	pod       *corev1.Pod
 	cr        *CustomResourceState
 }
 
 func NewTask(namespace string, cr *CustomResourceState, pod *corev1.Pod) *Task {
 	return &Task{
-		pod:       pod,
 		namespace: namespace,
+		pod:       pod,
 		cr:        cr,
 	}
 }

--- a/pkg/pod/k8s/task_test.go
+++ b/pkg/pod/k8s/task_test.go
@@ -32,13 +32,6 @@ func TestPkgPodK8STask(t *testing.T) {
 		DefaultNamespace,
 		&CustomResourceState{
 			Name: pkg.DefaultServiceName,
-			statefulsets: []appsv1.StatefulSet{
-				{
-					Spec: appsv1.StatefulSetSpec{
-						ServiceName: pkg.DefaultServiceName + "-" + pkg.EnvMongoDBReplset,
-					},
-				},
-			},
 		},
 		&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
1. Support many CRs in watchdog 'k8s' pod source (1 CustomResourceState struct per CR)
1. .Delete() method to 'k8s' pod source to delete deleted-CRs
1. Add unit tests to prove many CRs are returned