### PR TITLE
CLOUD-76: 'Pods', 'Services' and 'Statefulsets' must be public fields

### DIFF
--- a/pkg/pod/k8s/pods.go
+++ b/pkg/pod/k8s/pods.go
@@ -45,18 +45,18 @@ func getPodReplsetName(pod *corev1.Pod) (string, error) {
 // Kubernetes CR for PSMDB
 type CustomResourceState struct {
 	Name         string
-	pods         []corev1.Pod
-	services     []corev1.Service
-	statefulsets []appsv1.StatefulSet
+	Pods         []corev1.Pod
+	Services     []corev1.Service
+	Statefulsets []appsv1.StatefulSet
 }
 
 func (cr *CustomResourceState) getServiceFromPod(pod *corev1.Pod) *corev1.Service {
 	serviceName := pod.Name
-	for i, svc := range cr.services {
+	for i, svc := range cr.Services {
 		if svc.Name != serviceName {
 			continue
 		}
-		return &cr.services[i]
+		return &cr.Services[i]
 	}
 	return nil
 }
@@ -67,11 +67,11 @@ func (cr *CustomResourceState) getStatefulSetFromPod(pod *corev1.Pod) *appsv1.St
 		return nil
 	}
 	setServiceName := cr.Name + "-" + replsetName
-	for i, statefulset := range cr.statefulsets {
+	for i, statefulset := range cr.Statefulsets {
 		if statefulset.Spec.ServiceName != setServiceName {
 			continue
 		}
-		return &cr.statefulsets[i]
+		return &cr.Statefulsets[i]
 	}
 	return nil
 }
@@ -123,7 +123,7 @@ func (p *Pods) Pods() ([]string, error) {
 
 	pods := make([]string, 0)
 	for _, cr := range p.crs {
-		for _, pod := range cr.pods {
+		for _, pod := range cr.Pods {
 			if pod.Status.Phase != corev1.PodRunning && pod.Status.Phase != corev1.PodPending {
 				continue
 			}
@@ -140,8 +140,8 @@ func (p *Pods) GetTasks(podName string) ([]pod.Task, error) {
 
 	tasks := make([]pod.Task, 0)
 	for _, cr := range p.crs {
-		for i := range cr.pods {
-			pod := &cr.pods[i]
+		for i := range cr.Pods {
+			pod := &cr.Pods[i]
 			if pod.Name != podName {
 				continue
 			}

--- a/pkg/pod/k8s/pods_test.go
+++ b/pkg/pod/k8s/pods_test.go
@@ -84,8 +84,8 @@ func TestInternalPodK8SPods(t *testing.T) {
 
 	p.Update(&CustomResourceState{
 		Name:         "test-cluster",
-		pods:         corev1Pods,
-		statefulsets: statefulsets,
+		Pods:         corev1Pods,
+		Statefulsets: statefulsets,
 	})
 	pods, _ = p.Pods()
 	assert.Len(t, pods, 1)
@@ -101,7 +101,7 @@ func TestInternalPodK8SPods(t *testing.T) {
 	p2 := NewPods(DefaultNamespace)
 	p2.Update(&CustomResourceState{
 		Name: "test-cluster1",
-		pods: []corev1.Pod{
+		Pods: []corev1.Pod{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: t.Name() + "-1",
@@ -132,7 +132,7 @@ func TestInternalPodK8SPods(t *testing.T) {
 	})
 	p2.Update(&CustomResourceState{
 		Name: "test-cluster2",
-		pods: []corev1.Pod{
+		Pods: []corev1.Pod{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: t.Name() + "-2",
@@ -168,7 +168,7 @@ func TestInternalPodK8SPods(t *testing.T) {
 	corev1Pods[1].Status.Phase = corev1.PodSucceeded
 	p.Update(&CustomResourceState{
 		Name: "test-cluster",
-		pods: corev1Pods,
+		Pods: corev1Pods,
 	})
 	pods, _ = p.Pods()
 	assert.Len(t, pods, 0)

--- a/pkg/pod/k8s/task_test.go
+++ b/pkg/pod/k8s/task_test.go
@@ -116,7 +116,7 @@ func TestPkgPodK8STask(t *testing.T) {
 	assert.Equal(t, 27018, addr.Port)
 
 	// test .IsUpdating() is false
-	task.cr.statefulsets = []appsv1.StatefulSet{
+	task.cr.Statefulsets = []appsv1.StatefulSet{
 		{
 			Spec: appsv1.StatefulSetSpec{
 				ServiceName: pkg.DefaultServiceName + "-rs",
@@ -132,7 +132,7 @@ func TestPkgPodK8STask(t *testing.T) {
 	assert.False(t, task.IsUpdating())
 
 	// test .IsUpdating() is true if revisions are different
-	task.cr.statefulsets = []appsv1.StatefulSet{
+	task.cr.Statefulsets = []appsv1.StatefulSet{
 		{
 			Spec: appsv1.StatefulSetSpec{
 				ServiceName: pkg.DefaultServiceName + "-rs",
@@ -148,7 +148,7 @@ func TestPkgPodK8STask(t *testing.T) {
 	assert.True(t, task.IsUpdating())
 
 	// test .IsUpdating() is true if replica #s are different
-	task.cr.statefulsets = []appsv1.StatefulSet{
+	task.cr.Statefulsets = []appsv1.StatefulSet{
 		{
 			Spec: appsv1.StatefulSetSpec{
 				ServiceName: pkg.DefaultServiceName + "-rs",


### PR DESCRIPTION
This PR fixes a silly mistake in making my struct fields private.

1. Move 'pods', 'services' and 'statefulsets' slices to Public fields, so they can be set outside this module (required to fix CLOUD-76).