### PR TITLE
CLOUD-76: Fix duplicate replsets after multi-CR support

### DIFF
--- a/cmd/dcos-mongodb-controller/main.go
+++ b/cmd/dcos-mongodb-controller/main.go
@@ -182,7 +182,7 @@ func main() {
 			handleFailed(err)
 		}
 	case cmdUserUpdate.FullCommand():
-		uc, err := user.NewController(cnf, api.New(cnf.ServiceName, cnf.User.API))
+		uc, err := user.NewController(cnf, api.New(cnf.User.API))
 		if err != nil {
 			handleFailed(err)
 		}
@@ -193,7 +193,7 @@ func main() {
 			handleFailed(err)
 		}
 	case cmdUserRemove.FullCommand():
-		uc, err := user.NewController(cnf, api.New(cnf.ServiceName, cnf.User.API))
+		uc, err := user.NewController(cnf, api.New(cnf.User.API))
 		if err != nil {
 			handleFailed(err)
 		}
@@ -204,7 +204,7 @@ func main() {
 			handleFailed(err)
 		}
 	case cmdUserReloadSys.FullCommand():
-		uc, err := user.NewController(cnf, api.New(cnf.ServiceName, cnf.User.API))
+		uc, err := user.NewController(cnf, api.New(cnf.User.API))
 		if err != nil {
 			handleFailed(err)
 		}

--- a/cmd/dcos-mongodb-watchdog/main.go
+++ b/cmd/dcos-mongodb-watchdog/main.go
@@ -61,10 +61,6 @@ func main() {
 		API: &api.Config{},
 	}
 	app.Flag(
-		"service",
-		"DC/OS SDK service/framework name, this flag or env var "+pkg.EnvServiceName+" is required",
-	).Default(pkg.DefaultServiceName).Envar(pkg.EnvServiceName).StringVar(&cnf.ServiceName)
-	app.Flag(
 		"username",
 		"MongoDB clusterAdmin username, this flag or env var "+pkg.EnvMongoDBClusterAdminUser+" is required",
 	).Envar(pkg.EnvMongoDBClusterAdminUser).Required().StringVar(&cnf.Username)
@@ -127,7 +123,7 @@ func main() {
 	//	)
 	//}
 
-	apiClient := api.New(cnf.ServiceName, cnf.API)
+	apiClient := api.New(cnf.API)
 	wMetrics := metrics.NewCollector()
 	quit := make(chan bool)
 	watchdog := watchdog.New(cnf, apiClient, wMetrics, &quit)

--- a/internal/dcos/api/dcos.go
+++ b/internal/dcos/api/dcos.go
@@ -38,17 +38,15 @@ var (
 
 // SDKClient is an HTTP client for the DC/OS SDK API
 type SDKClient struct {
-	ServiceName string
-	config      *Config
-	scheme      HTTPScheme
+	config *Config
+	scheme HTTPScheme
 }
 
 // New creates a new SDKClient struct configured for use with the DC/OS SDK API
-func New(frameworkName string, config *Config) *SDKClient {
+func New(config *Config) *SDKClient {
 	c := &SDKClient{
-		ServiceName: frameworkName,
-		config:      config,
-		scheme:      HTTPSchemePlain,
+		config: config,
+		scheme: HTTPSchemePlain,
 	}
 	if config.Secure {
 		c.scheme = HTTPSchemeSecure

--- a/internal/dcos/api/main_test.go
+++ b/internal/dcos/api/main_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/percona/mongodb-orchestration-tools/pkg"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,7 +32,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	testAPI = New(pkg.DefaultServiceName, testAPIConfig)
+	testAPI = New(testAPIConfig)
 	os.Exit(m.Run())
 }
 
@@ -41,12 +40,11 @@ func TestInternalAPINew(t *testing.T) {
 	testAPI = nil
 	assert.Nil(t, testAPI)
 
-	testAPI = New(pkg.DefaultServiceName, testAPIConfig)
+	testAPI = New(testAPIConfig)
 	assert.Equal(t, testAPIConfig, testAPI.config, "api.config is incorrect")
-	assert.Equal(t, pkg.DefaultServiceName, testAPI.ServiceName, "api.ServiceName is incorrect")
 	assert.Equal(t, HTTPSchemeSecure, testAPI.scheme, "api.scheme is incorrect")
 
 	testAPIConfig.Secure = false
-	testAPI = New(pkg.DefaultServiceName, testAPIConfig)
+	testAPI = New(testAPIConfig)
 	assert.Equal(t, HTTPSchemePlain, testAPI.scheme, "api.scheme is incorrect")
 }

--- a/internal/dcos/api/pod.go
+++ b/internal/dcos/api/pod.go
@@ -41,7 +41,7 @@ func (c *SDKClient) GetTasks(podName string) ([]pod.Task, error) {
 		return tasks, err
 	}
 	for _, taskData := range tasksData {
-		tasks = append(tasks, dcos.NewTask(taskData, c.ServiceName, podName))
+		tasks = append(tasks, dcos.NewTask(taskData, podName))
 	}
 	return tasks, nil
 }

--- a/pkg/pod/dcos/task.go
+++ b/pkg/pod/dcos/task.go
@@ -16,6 +16,7 @@ package dcos
 
 import (
 	"errors"
+	"os"
 	"strconv"
 	"strings"
 
@@ -44,9 +45,8 @@ func (s TaskState) String() string {
 }
 
 type Task struct {
-	frameworkName string
-	podName       string
-	data          *TaskData
+	podName string
+	data    *TaskData
 }
 
 type TaskData struct {
@@ -77,11 +77,10 @@ type TaskStatus struct {
 	State *TaskState `json:"state"`
 }
 
-func NewTask(data *TaskData, frameworkName, podName string) *Task {
+func NewTask(data *TaskData, podName string) *Task {
 	return &Task{
-		data:          data,
-		frameworkName: frameworkName,
-		podName:       podName,
+		data:    data,
+		podName: podName,
 	}
 }
 
@@ -98,6 +97,10 @@ func (task *Task) getEnvVar(variableName string) (string, error) {
 
 func (task *Task) Name() string {
 	return task.data.Info.Name
+}
+
+func (task *Task) Service() string {
+	return os.Getenv(pkg.EnvServiceName)
 }
 
 func (task *Task) HasState() bool {
@@ -134,7 +137,7 @@ func (task *Task) IsTaskType(taskType pod.TaskType) bool {
 
 func (task *Task) GetMongoAddr() (*db.Addr, error) {
 	addr := &db.Addr{
-		Host: task.data.Info.Name + "." + task.frameworkName + "." + AutoIPDNSSuffix,
+		Host: task.data.Info.Name + "." + task.Service() + "." + AutoIPDNSSuffix,
 	}
 	portStr, err := task.getEnvVar(pkg.EnvMongoDBPort)
 	if err != nil {

--- a/pkg/pod/dcos/task_test.go
+++ b/pkg/pod/dcos/task_test.go
@@ -15,6 +15,7 @@
 package dcos
 
 import (
+	"os"
 	"testing"
 
 	"github.com/percona/mongodb-orchestration-tools/pkg"
@@ -27,7 +28,7 @@ func TestPkgPodDCOSTask(t *testing.T) {
 		Info: &TaskInfo{
 			Name: t.Name(),
 		},
-	}, "test", "testPod")
+	}, "testPod")
 	assert.Implements(t, (*pod.Task)(nil), task)
 	assert.Equal(t, t.Name(), task.Name())
 
@@ -41,7 +42,7 @@ func TestPkgPodDCOSTaskState(t *testing.T) {
 		Status: &TaskStatus{
 			State: &TaskStateRunning,
 		},
-	}, "test", "testPod")
+	}, "testPod")
 	assert.NotNil(t, task.State())
 	assert.Equal(t, string(TaskStateRunning), task.State().String())
 	assert.True(t, task.IsRunning())
@@ -59,7 +60,7 @@ func TestPkgPodDCOSTaskIsTaskType(t *testing.T) {
 				Value: "mongodb-executor-linux",
 			},
 		},
-	}, "test", "testPod")
+	}, "testPod")
 	assert.False(t, task.IsTaskType(pod.TaskTypeMongod))
 
 	task.data.Info.Name = "mongodb-rs-mongod"
@@ -67,6 +68,9 @@ func TestPkgPodDCOSTaskIsTaskType(t *testing.T) {
 }
 
 func TestPkgPodDCOSTaskGetMongoAddr(t *testing.T) {
+	os.Setenv(pkg.EnvServiceName, "testService")
+	defer os.Unsetenv(pkg.EnvServiceName)
+
 	task := NewTask(&TaskData{
 		Info: &TaskInfo{
 			Name: t.Name(),
@@ -76,7 +80,7 @@ func TestPkgPodDCOSTaskGetMongoAddr(t *testing.T) {
 				},
 			},
 		},
-	}, "test", "testPod")
+	}, "testPod")
 	_, err := task.GetMongoAddr()
 	assert.Error(t, err)
 
@@ -86,7 +90,7 @@ func TestPkgPodDCOSTaskGetMongoAddr(t *testing.T) {
 	}}
 	addr, err := task.GetMongoAddr()
 	assert.NoError(t, err)
-	assert.Equal(t, t.Name()+".test."+AutoIPDNSSuffix, addr.Host)
+	assert.Equal(t, t.Name()+".testService."+AutoIPDNSSuffix, addr.Host)
 	assert.Equal(t, 27017, addr.Port)
 }
 
@@ -104,7 +108,7 @@ func TestPkgPodDCOSTaskGetReplsetName(t *testing.T) {
 				},
 			},
 		},
-	}, "test", "testPod")
+	}, "testPod")
 	rsName, err := task.GetMongoReplsetName()
 	assert.NoError(t, err)
 	assert.Equal(t, "rs", rsName)

--- a/pkg/pod/k8s/task.go
+++ b/pkg/pod/k8s/task.go
@@ -63,6 +63,10 @@ func NewTask(namespace string, cr *CustomResourceState, pod *corev1.Pod) *Task {
 	}
 }
 
+func (t *Task) Service() string {
+	return t.cr.Name
+}
+
 func (t *Task) State() pod.TaskState {
 	return NewTaskState(t.pod.Status)
 }

--- a/pkg/pod/mocks/Task.go
+++ b/pkg/pod/mocks/Task.go
@@ -124,6 +124,20 @@ func (_m *Task) Name() string {
 	return r0
 }
 
+// Service provides a mock function with given fields:
+func (_m *Task) Service() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // State provides a mock function with given fields:
 func (_m *Task) State() pod.TaskState {
 	ret := _m.Called()

--- a/pkg/pod/task.go
+++ b/pkg/pod/task.go
@@ -38,6 +38,7 @@ type TaskState interface {
 
 type Task interface {
 	Name() string
+	Service() string
 	State() TaskState
 	HasState() bool
 	IsRunning() bool

--- a/watchdog/config/config.go
+++ b/watchdog/config/config.go
@@ -38,7 +38,6 @@ var (
 type Config struct {
 	Username       string
 	Password       string
-	ServiceName    string
 	IgnorePods     []string
 	API            *api.Config
 	APIPoll        time.Duration

--- a/watchdog/replset/main_test.go
+++ b/watchdog/replset/main_test.go
@@ -42,11 +42,10 @@ var (
 	testReplsetName   = "rs"
 	testReplset       = &Replset{}
 	testReplsetMongod = &Mongod{
-		Host:        "test123",
-		Port:        12345,
-		Replset:     testReplsetName,
-		PodName:     "mongod",
-		ServiceName: "test",
+		Host:    "test123",
+		Port:    12345,
+		Replset: testReplsetName,
+		PodName: "mongod",
 	}
 )
 

--- a/watchdog/replset/member.go
+++ b/watchdog/replset/member.go
@@ -23,26 +23,24 @@ import (
 )
 
 type Mongod struct {
-	Host        string
-	Port        int
-	Replset     string
-	ServiceName string
-	PodName     string
-	Task        pod.Task
+	Host    string
+	Port    int
+	Replset string
+	PodName string
+	Task    pod.Task
 }
 
-func NewMongod(task pod.Task, serviceName string, podName string) (*Mongod, error) {
+func NewMongod(task pod.Task, podName string) (*Mongod, error) {
 	addr, err := task.GetMongoAddr()
 	if err != nil {
 		return nil, err
 	}
 
 	mongod := &Mongod{
-		ServiceName: serviceName,
-		PodName:     podName,
-		Task:        task,
-		Host:        addr.Host,
-		Port:        addr.Port,
+		PodName: podName,
+		Task:    task,
+		Host:    addr.Host,
+		Port:    addr.Port,
 	}
 
 	mongod.Replset, err = task.GetMongoReplsetName()

--- a/watchdog/replset/member_test.go
+++ b/watchdog/replset/member_test.go
@@ -41,7 +41,7 @@ func TestWatchdogReplsetNewMongod(t *testing.T) {
 	podTask.On("GetMongoReplsetName").Return(testutils.MongodbReplsetName, nil)
 
 	var err error
-	testMongod, err = NewMongod(podTask, pkg.DefaultServiceName, "mongo-"+testutils.MongodbReplsetName)
+	testMongod, err = NewMongod(podTask, "mongo-"+testutils.MongodbReplsetName)
 	assert.NoError(t, err, "replset.NewMongod() returned unexpected error")
 	assert.NotNil(t, testMongod, "replset.NewMongod() should not return a nil Mongod")
 }

--- a/watchdog/replset/replset.go
+++ b/watchdog/replset/replset.go
@@ -31,16 +31,18 @@ const (
 
 type Replset struct {
 	sync.Mutex
-	Name    string
-	config  *config.Config
-	members map[string]*Mongod
+	Name        string
+	ServiceName string
+	config      *config.Config
+	members     map[string]*Mongod
 }
 
-func New(config *config.Config, name string) *Replset {
+func New(config *config.Config, serviceName, rsName string) *Replset {
 	return &Replset{
-		Name:    name,
-		config:  config,
-		members: make(map[string]*Mongod),
+		Name:        rsName,
+		ServiceName: serviceName,
+		config:      config,
+		members:     make(map[string]*Mongod),
 	}
 }
 

--- a/watchdog/replset/replset.go
+++ b/watchdog/replset/replset.go
@@ -36,9 +36,9 @@ type Replset struct {
 	members map[string]*Mongod
 }
 
-func New(config *config.Config, rsName string) *Replset {
+func New(config *config.Config, name string) *Replset {
 	return &Replset{
-		Name:    rsName,
+		Name:    name,
 		config:  config,
 		members: make(map[string]*Mongod),
 	}

--- a/watchdog/replset/replset.go
+++ b/watchdog/replset/replset.go
@@ -31,18 +31,16 @@ const (
 
 type Replset struct {
 	sync.Mutex
-	Name        string
-	ServiceName string
-	config      *config.Config
-	members     map[string]*Mongod
+	Name    string
+	config  *config.Config
+	members map[string]*Mongod
 }
 
-func New(config *config.Config, serviceName, rsName string) *Replset {
+func New(config *config.Config, rsName string) *Replset {
 	return &Replset{
-		Name:        rsName,
-		ServiceName: serviceName,
-		config:      config,
-		members:     make(map[string]*Mongod),
+		Name:    rsName,
+		config:  config,
+		members: make(map[string]*Mongod),
 	}
 }
 

--- a/watchdog/replset/replset_test.go
+++ b/watchdog/replset/replset_test.go
@@ -43,11 +43,10 @@ func TestWatchdogReplsetUpdateMember(t *testing.T) {
 	// test that an error is returned if the MaxMembers is reached
 	replset := New(testWatchdogConfig, testReplsetName)
 	mongod := &Mongod{
-		Host:        t.Name(),
-		Port:        27017,
-		Replset:     testReplsetName,
-		PodName:     "mongod",
-		ServiceName: "test",
+		Host:    t.Name(),
+		Port:    27017,
+		Replset: testReplsetName,
+		PodName: "mongod",
 	}
 	for len(replset.members) < MaxMembers {
 		assert.NoError(t, replset.UpdateMember(mongod))

--- a/watchdog/replset/state.go
+++ b/watchdog/replset/state.go
@@ -233,7 +233,7 @@ func (s *State) AddConfigMembers(session *mgo.Session, configManager rsConfig.Ma
 	for _, mongod := range members {
 		member := rsConfig.NewMember(mongod.Name())
 		member.Tags = &rsConfig.ReplsetTags{
-			serviceTagName: mongod.ServiceName,
+			serviceTagName: mongod.Task.Service(),
 		}
 		if len(s.Config.Members) >= MaxMembers {
 			log.Errorf("Maximum replset member count reached, cannot add member")
@@ -250,7 +250,7 @@ func (s *State) AddConfigMembers(session *mgo.Session, configManager rsConfig.Ma
 			member.Priority = 0
 			member.Tags = &rsConfig.ReplsetTags{
 				"backup":       "true",
-				serviceTagName: mongod.ServiceName,
+				serviceTagName: mongod.Task.Service(),
 			}
 			member.Votes = 0
 		} else if mongod.Task.IsTaskType(pod.TaskTypeArbiter) {

--- a/watchdog/watchdog.go
+++ b/watchdog/watchdog.go
@@ -98,15 +98,16 @@ func (w *Watchdog) podMongodFetcher(podName string, wg *sync.WaitGroup) {
 		}
 
 		// ensure the replset has a watcher started
-		if !w.watcherManager.HasWatcher(mongod.ServiceName, mongod.Replset) {
-			rs := replset.New(w.config, mongod.ServiceName, mongod.Replset)
-			w.watcherManager.Watch(rs)
+		serviceName := mongod.Task.Service()
+		if !w.watcherManager.HasWatcher(serviceName, mongod.Replset) {
+			rs := replset.New(w.config, mongod.Replset)
+			w.watcherManager.Watch(serviceName, rs)
 		}
 
 		// send the update to the watcher for the given replset
-		watcher := w.watcherManager.Get(mongod.ServiceName, mongod.Replset)
+		watcher := w.watcherManager.Get(serviceName, mongod.Replset)
 		if watcher == nil {
-			log.Errorf("Cannot find replset watcher for service %s, replset %s", mongod.ServiceName, mongod.Replset)
+			log.Errorf("Cannot find replset watcher for service %s, replset %s", serviceName, mongod.Replset)
 			continue
 		}
 		watcher.UpdateMongod(mongod)
@@ -177,7 +178,6 @@ func (w *Watchdog) Run() {
 
 	log.WithFields(log.Fields{
 		"version": tools.Version,
-		"service": w.config.ServiceName,
 		"go":      runtime.Version(),
 		"source":  w.podSource.Name(),
 	}).Info("Starting watchdog")

--- a/watchdog/watchdog.go
+++ b/watchdog/watchdog.go
@@ -47,7 +47,7 @@ func New(config *config.Config, podSource pod.Source, metricCollector *metrics.C
 		podSource:      podSource,
 		metrics:        metricCollector,
 		quit:           quit,
-		watcherManager: watcher.NewManager(config, quit, activePods),
+		watcherManager: watcher.NewManager(config, activePods),
 		activePods:     activePods,
 	}
 }
@@ -174,6 +174,8 @@ func (w *Watchdog) StopWatcher(serviceName, rsName string) {
 }
 
 func (w *Watchdog) Run() {
+	w.setRunning(true)
+
 	log.WithFields(log.Fields{
 		"version": tools.Version,
 		"go":      runtime.Version(),
@@ -190,6 +192,7 @@ func (w *Watchdog) Run() {
 		case <-w.quit:
 			log.Info("Stopping watchers")
 			ticker.Stop()
+			w.setRunning(false)
 			w.watcherManager.Close()
 			return
 		}

--- a/watchdog/watchdog.go
+++ b/watchdog/watchdog.go
@@ -88,7 +88,7 @@ func (w *Watchdog) podMongodFetcher(podName string, wg *sync.WaitGroup) {
 			continue
 		}
 
-		mongod, err := replset.NewMongod(task, w.config.ServiceName, podName)
+		mongod, err := replset.NewMongod(task, podName)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"task":  task.Name(),

--- a/watchdog/watchdog_test.go
+++ b/watchdog/watchdog_test.go
@@ -35,7 +35,6 @@ var (
 	testWatchdog *Watchdog
 	testQuitChan = make(chan bool)
 	testConfig   = &config.Config{
-		ServiceName: "test",
 		Username:    testutils.MongodbAdminUser,
 		Password:    testutils.MongodbAdminPassword,
 		APIPoll:     time.Millisecond * 75,
@@ -81,6 +80,7 @@ func TestWatchdogRun(t *testing.T) {
 		mockTask.On("IsTaskType", pod.TaskTypeArbiter).Return(false).Once()
 		mockTask.On("IsTaskType", pod.TaskTypeMongod).Return(true)
 		mockTask.On("Name").Return(t.Name() + "-" + strconv.Itoa(i))
+		mockTask.On("Service").Return("testService")
 
 		mockTaskState := &mocks.TaskState{}
 		mockTaskState.On("String").Return("RUNNING")
@@ -105,7 +105,7 @@ func TestWatchdogRun(t *testing.T) {
 	}
 
 	// test watchdog started a watcher and fetched data
-	watcher := testWatchdog.watcherManager.Get(testutils.MongodbReplsetName)
+	watcher := testWatchdog.watcherManager.Get("testService", testutils.MongodbReplsetName)
 	assert.NotNil(t, watcher)
 	tries = 0
 	for tries < 100 {

--- a/watchdog/watchdog_test.go
+++ b/watchdog/watchdog_test.go
@@ -58,7 +58,7 @@ func TestWatchdogDoIgnorePod(t *testing.T) {
 func TestWatchdogRun(t *testing.T) {
 	testPodSource := &mocks.Source{}
 	wMetrics := metrics.NewCollector()
-	testWatchdog := New(testConfig, testPodSource, wMetrics, &testQuitChan)
+	testWatchdog := New(testConfig, testPodSource, wMetrics, testQuitChan)
 	assert.NotNil(t, testWatchdog, ".New() returned nil")
 
 	testPodSource.On("Name").Return("test")

--- a/watchdog/watcher/main_test.go
+++ b/watchdog/watcher/main_test.go
@@ -34,8 +34,7 @@ var (
 		ReplsetPoll: 500 * time.Millisecond,
 		SSL:         &db.SSLConfig{},
 	}
-	testStopChan = make(chan bool)
-	testWatchRs  = replset.New(testConfig, testutils.MongodbReplsetName)
+	testWatchRs = replset.New(testConfig, testutils.MongodbReplsetName)
 )
 
 func TestMain(m *testing.M) {

--- a/watchdog/watcher/main_test.go
+++ b/watchdog/watcher/main_test.go
@@ -34,9 +34,10 @@ var (
 		ReplsetPoll: 500 * time.Millisecond,
 		SSL:         &db.SSLConfig{},
 	}
-	testStopChan = make(chan bool)
-	testWatchRs  = replset.New(testConfig, testutils.MongodbReplsetName)
-	rsName       = testutils.MongodbReplsetName
+	testStopChan       = make(chan bool)
+	testWatchRsService = "testService"
+	testWatchRs        = replset.New(testConfig, testWatchRsService, testutils.MongodbReplsetName)
+	rsName             = testutils.MongodbReplsetName
 )
 
 func TestMain(m *testing.M) {

--- a/watchdog/watcher/main_test.go
+++ b/watchdog/watcher/main_test.go
@@ -34,10 +34,9 @@ var (
 		ReplsetPoll: 500 * time.Millisecond,
 		SSL:         &db.SSLConfig{},
 	}
-	testStopChan       = make(chan bool)
-	testWatchRsService = "testService"
-	testWatchRs        = replset.New(testConfig, testWatchRsService, testutils.MongodbReplsetName)
-	rsName             = testutils.MongodbReplsetName
+	testStopChan = make(chan bool)
+	testWatchRs  = replset.New(testConfig, testutils.MongodbReplsetName)
+	rsName       = testutils.MongodbReplsetName
 )
 
 func TestMain(m *testing.M) {

--- a/watchdog/watcher/main_test.go
+++ b/watchdog/watcher/main_test.go
@@ -36,7 +36,6 @@ var (
 	}
 	testStopChan = make(chan bool)
 	testWatchRs  = replset.New(testConfig, testutils.MongodbReplsetName)
-	rsName       = testutils.MongodbReplsetName
 )
 
 func TestMain(m *testing.M) {

--- a/watchdog/watcher/manager.go
+++ b/watchdog/watcher/manager.go
@@ -77,13 +77,7 @@ func (wm *WatcherManager) Get(serviceName, rsName string) *Watcher {
 	wm.Lock()
 	defer wm.Unlock()
 
-	for watcherName, watcher := range wm.watchers {
-		if watcherName == serviceName+"-"+rsName {
-			return watcher
-		}
-	}
-
-	return nil
+	return wm.watchers[serviceName+"-"+rsName]
 }
 
 func (wm *WatcherManager) stopWatcher(name string) {
@@ -99,6 +93,7 @@ func (wm *WatcherManager) stopWatcher(name string) {
 func (wm *WatcherManager) Stop(serviceName, rsName string) {
 	wm.Lock()
 	defer wm.Unlock()
+
 	wm.stopWatcher(serviceName + "-" + rsName)
 }
 

--- a/watchdog/watcher/manager.go
+++ b/watchdog/watcher/manager.go
@@ -28,7 +28,7 @@ type Manager interface {
 	Get(serviceName, rsName string) *Watcher
 	HasWatcher(serviceName, rsName string) bool
 	Stop(serviceName, rsName string)
-	Watch(rs *replset.Replset)
+	Watch(serviceName string, rs *replset.Replset)
 }
 
 type watcherState struct {
@@ -59,11 +59,11 @@ func (wm *WatcherManager) HasWatcher(serviceName, rsName string) bool {
 	return wm.Get(serviceName, rsName) != nil
 }
 
-func (wm *WatcherManager) Watch(rs *replset.Replset) {
-	if !wm.HasWatcher(rs.ServiceName, rs.Name) {
+func (wm *WatcherManager) Watch(serviceName string, rs *replset.Replset) {
+	if !wm.HasWatcher(serviceName, rs.Name) {
 		log.WithFields(log.Fields{
 			"replset": rs.Name,
-			"service": rs.ServiceName,
+			"service": serviceName,
 		}).Info("Starting replset watcher")
 
 		wm.Lock()
@@ -71,7 +71,7 @@ func (wm *WatcherManager) Watch(rs *replset.Replset) {
 		quitChan := make(chan bool)
 		w := &watcherState{
 			rsName:      rs.Name,
-			serviceName: rs.ServiceName,
+			serviceName: serviceName,
 			quit:        quitChan,
 			watcher:     New(rs, wm.config, &quitChan, wm.activePods),
 		}

--- a/watchdog/watcher/manager.go
+++ b/watchdog/watcher/manager.go
@@ -41,16 +41,14 @@ type watcherState struct {
 type WatcherManager struct {
 	sync.Mutex
 	config     *config.Config
-	stop       chan bool
 	watchers   []*watcherState
 	activePods *pod.Pods
 }
 
-func NewManager(config *config.Config, stop chan bool, activePods *pod.Pods) *WatcherManager {
+func NewManager(config *config.Config, activePods *pod.Pods) *WatcherManager {
 	return &WatcherManager{
 		config:     config,
 		activePods: activePods,
-		stop:       stop,
 		watchers:   make([]*watcherState, 0),
 	}
 }

--- a/watchdog/watcher/manager.go
+++ b/watchdog/watcher/manager.go
@@ -31,13 +31,6 @@ type Manager interface {
 	Watch(serviceName string, rs *replset.Replset)
 }
 
-type watcherState struct {
-	rsName      string
-	serviceName string
-	watcher     *Watcher
-	quit        chan bool
-}
-
 type WatcherManager struct {
 	sync.Mutex
 	config     *config.Config

--- a/watchdog/watcher/manager_test.go
+++ b/watchdog/watcher/manager_test.go
@@ -39,7 +39,6 @@ func TestWatchdogWatcherManagerWatch(t *testing.T) {
 	apiTask := &mocks.Task{}
 	apiTask.On("Name").Return("test")
 	apiTask.On("IsUpdating").Return(false)
-
 	apiTaskState := &mocks.TaskState{}
 	apiTaskState.On("String").Return("OK")
 	apiTask.On("State").Return(apiTaskState)
@@ -57,7 +56,7 @@ func TestWatchdogWatcherManagerWatch(t *testing.T) {
 	assert.NoError(t, testWatchRs.UpdateMember(mongod))
 
 	assert.Nil(t, testManager.Get(testWatchRsService, "does-not-exist"), ".Get() returned data for non-existing watcher")
-	assert.False(t, testManager.HasWatcher(testWatchRsService, rsName))
+	assert.False(t, testManager.HasWatcher(testWatchRsService, testutils.MongodbReplsetName))
 
 	// secondary1
 	mongod.Port, _ = strconv.Atoi(testutils.MongodbSecondary1Port)
@@ -69,7 +68,7 @@ func TestWatchdogWatcherManagerWatch(t *testing.T) {
 
 	tries := 0
 	for tries < 20 {
-		if testManager.HasWatcher(testWatchRsService, rsName) && testManager.Get(testWatchRsService, rsName).IsRunning() {
+		if testManager.HasWatcher(testWatchRsService, testutils.MongodbReplsetName) && testManager.Get(testWatchRsService, testutils.MongodbReplsetName).IsRunning() {
 			break
 		}
 		time.Sleep(time.Second)
@@ -79,7 +78,7 @@ func TestWatchdogWatcherManagerWatch(t *testing.T) {
 		assert.FailNow(t, "failed to start watcher after 20 tries")
 	}
 
-	state := testManager.Get(testWatchRsService, rsName).state
+	state := testManager.Get(testWatchRsService, testutils.MongodbReplsetName).state
 	tries = 0
 	for tries < 100 {
 		status := state.GetStatus()
@@ -92,19 +91,54 @@ func TestWatchdogWatcherManagerWatch(t *testing.T) {
 	if tries >= 100 {
 		assert.FailNow(t, "failed to run fetch in watcher after 20 tries")
 	}
+	assert.True(t, testManager.HasWatcher(testWatchRsService, testutils.MongodbReplsetName))
 
-	assert.True(t, testManager.HasWatcher(testWatchRsService, rsName))
-	testManager.Close()
+	// Test 2 x clusters with one watchdog, both with the same replset name
+	// https://jira.percona.com/browse/CLOUD-97
+	testWatchRs2 := replset.New(testConfig, testutils.MongodbReplsetName)
+	go testManager.Watch(testWatchRsService+"2", testWatchRs2)
+
+	apiTask2 := &mocks.Task{}
+	apiTask2.On("Name").Return("test")
+	apiTask2.On("IsUpdating").Return(false)
+	apiTaskState2 := &mocks.TaskState{}
+	apiTaskState2.On("String").Return("OK")
+	apiTask2.On("State").Return(apiTaskState2)
+
+	mongod2 := &replset.Mongod{
+		Host:    testutils.MongodbHost,
+		Port:    port,
+		Task:    apiTask2,
+		PodName: t.Name() + "2",
+	}
+	assert.NoError(t, testWatchRs2.UpdateMember(mongod2))
 
 	tries = 0
 	for tries < 20 {
-		if !testManager.Get(testWatchRsService, rsName).IsRunning() {
-			return
+		if testManager.HasWatcher(testWatchRsService+"2", testutils.MongodbReplsetName) && testManager.Get(testWatchRsService+"2", testutils.MongodbReplsetName).IsRunning() {
+			break
 		}
 		time.Sleep(time.Second)
 		tries++
 	}
-	assert.FailNow(t, "Failed to close watcher manager after 20 tries")
+	if tries >= 20 {
+		assert.FailNow(t, "failed to start watcher after 20 tries")
+	}
+	assert.True(t, testManager.HasWatcher(testWatchRsService+"2", testutils.MongodbReplsetName))
 
-	assert.NotContains(t, testManager.watchers, rsName)
+	// test closing manager
+	testManager.Close()
+	tries = 0
+	for tries < 20 {
+		if testManager.Get(testWatchRsService, testutils.MongodbReplsetName) == nil && testManager.Get(testWatchRsService+"2", testutils.MongodbReplsetName) == nil {
+			break
+		}
+		time.Sleep(time.Second)
+		tries++
+	}
+	if tries >= 20 {
+		assert.FailNow(t, "Failed to close watcher manager after 20 tries")
+	}
+	assert.False(t, testManager.HasWatcher(testWatchRsService, testutils.MongodbReplsetName))
+	assert.False(t, testManager.HasWatcher(testWatchRsService+"2", testutils.MongodbReplsetName))
 }

--- a/watchdog/watcher/manager_test.go
+++ b/watchdog/watcher/manager_test.go
@@ -54,8 +54,8 @@ func TestWatchdogWatcherManagerWatch(t *testing.T) {
 	}
 	assert.NoError(t, testWatchRs.UpdateMember(mongod))
 
-	assert.Nil(t, testManager.Get("does-not-exist"), ".Get() returned data for non-existing watcher")
-	assert.False(t, testManager.HasWatcher(rsName))
+	assert.Nil(t, testManager.Get(testWatchRsService, "does-not-exist"), ".Get() returned data for non-existing watcher")
+	assert.False(t, testManager.HasWatcher(testWatchRsService, rsName))
 
 	// secondary1
 	mongod.Port, _ = strconv.Atoi(testutils.MongodbSecondary1Port)
@@ -67,7 +67,7 @@ func TestWatchdogWatcherManagerWatch(t *testing.T) {
 
 	tries := 0
 	for tries < 20 {
-		if testManager.HasWatcher(rsName) && testManager.Get(rsName).IsRunning() {
+		if testManager.HasWatcher(testWatchRsService, rsName) && testManager.Get(testWatchRsService, rsName).IsRunning() {
 			break
 		}
 		time.Sleep(time.Second)
@@ -77,7 +77,7 @@ func TestWatchdogWatcherManagerWatch(t *testing.T) {
 		assert.FailNow(t, "failed to start watcher after 20 tries")
 	}
 
-	state := testManager.Get(rsName).state
+	state := testManager.Get(testWatchRsService, rsName).state
 	tries = 0
 	for tries < 100 {
 		status := state.GetStatus()
@@ -96,7 +96,7 @@ func TestWatchdogWatcherManagerWatch(t *testing.T) {
 
 	tries = 0
 	for tries < 20 {
-		if !testManager.Get(rsName).IsRunning() {
+		if !testManager.Get(testWatchRsService, rsName).IsRunning() {
 			return
 		}
 		time.Sleep(time.Second)

--- a/watchdog/watcher/manager_test.go
+++ b/watchdog/watcher/manager_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const testWatchRsService = "testService"
+
 func TestWatchdogWatcherManagerWatch(t *testing.T) {
 	testutils.DoSkipTest(t)
 
@@ -42,7 +44,7 @@ func TestWatchdogWatcherManagerWatch(t *testing.T) {
 	apiTaskState.On("String").Return("OK")
 	apiTask.On("State").Return(apiTaskState)
 
-	go testManager.Watch(testWatchRs)
+	go testManager.Watch(testWatchRsService, testWatchRs)
 
 	// primary
 	port, _ := strconv.Atoi(testutils.MongodbPrimaryPort)
@@ -91,7 +93,7 @@ func TestWatchdogWatcherManagerWatch(t *testing.T) {
 		assert.FailNow(t, "failed to run fetch in watcher after 20 tries")
 	}
 
-	assert.Contains(t, testManager.watchers, rsName)
+	assert.True(t, testManager.HasWatcher(testWatchRsService, rsName))
 	testManager.Close()
 
 	tries = 0

--- a/watchdog/watcher/manager_test.go
+++ b/watchdog/watcher/manager_test.go
@@ -92,6 +92,8 @@ func TestWatchdogWatcherManagerWatch(t *testing.T) {
 		assert.FailNow(t, "failed to run fetch in watcher after 20 tries")
 	}
 	assert.True(t, testManager.HasWatcher(testWatchRsService, testutils.MongodbReplsetName))
+	rs := testManager.Get(testWatchRsService, testutils.MongodbReplsetName).replset
+	assert.Len(t, rs.GetMembers(), 3)
 
 	// Test 2 x clusters with one watchdog, both with the same replset name
 	// https://jira.percona.com/browse/CLOUD-97
@@ -125,6 +127,8 @@ func TestWatchdogWatcherManagerWatch(t *testing.T) {
 		assert.FailNow(t, "failed to start watcher after 20 tries")
 	}
 	assert.True(t, testManager.HasWatcher(testWatchRsService+"2", testutils.MongodbReplsetName))
+	rs = testManager.Get(testWatchRsService+"2", testutils.MongodbReplsetName).replset
+	assert.Len(t, rs.GetMembers(), 1)
 
 	// test closing manager
 	testManager.Close()

--- a/watchdog/watcher/manager_test.go
+++ b/watchdog/watcher/manager_test.go
@@ -33,7 +33,7 @@ func TestWatchdogWatcherManagerWatch(t *testing.T) {
 
 	pods := pod.NewPods()
 	pods.Set([]string{t.Name()})
-	testManager = NewManager(testConfig, &testStopChan, pods)
+	testManager = NewManager(testConfig, pods)
 	assert.NotNil(t, testManager)
 
 	apiTask := &mocks.Task{}

--- a/watchdog/watcher/watcher_test.go
+++ b/watchdog/watcher/watcher_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestGetScaledDownMembers(t *testing.T) {
-	rs := replset.New(nil, testWatchRsService, "test")
+	rs := replset.New(nil, "test")
 	rs.UpdateMember(&replset.Mongod{
 		Host:    "scaled-down",
 		Port:    27017,

--- a/watchdog/watcher/watcher_test.go
+++ b/watchdog/watcher/watcher_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestGetScaledDownMembers(t *testing.T) {
-	rs := replset.New(nil, "test")
+	rs := replset.New(nil, testWatchRsService, "test")
 	rs.UpdateMember(&replset.Mongod{
 		Host:    "scaled-down",
 		Port:    27017,


### PR DESCRIPTION
1. Move watchdog/watcher/manager.go to support many replsets with the same name but different CR/serviceName.
1. Remove legacy hardcoding of ServiceName in watchdog.
    1. DC/OS Pod Source pulls serviceName from the environment (DC/OS supports 1 x cluster only).
    1. K8S Pod Source gets the ServiceName from the PSMDB CR 'Name' field.
1. Add/fix unit tests for changes to watchdog/watcher/manager.go and test 2 x clusters/CRs.
    1. Update Task mock for pkg/pod change.
    1. Fix race conditions in watchdog/watcher/manager.go .Stop().