### PR TITLE
Skip TestWatchdogRun unless ENABLE_MONGODB_TESTS=true

### DIFF
--- a/watchdog/watchdog_test.go
+++ b/watchdog/watchdog_test.go
@@ -56,6 +56,8 @@ func TestWatchdogDoIgnorePod(t *testing.T) {
 }
 
 func TestWatchdogRun(t *testing.T) {
+	testutils.DoSkipTest(t)
+
 	testPodSource := &mocks.Source{}
 	wMetrics := metrics.NewCollector()
 	testWatchdog := New(testConfig, testPodSource, wMetrics, testQuitChan)


### PR DESCRIPTION
This test was missing the testutils.DoSkipTest(t) call that is needed for tests that use a MongoDB connection.

This fixes the DC/OS Mesosphere build that does not start MongoDB so that PMDCOS-5 can be completed.