### PR TITLE
PMDCOS-5: Fix issue with pointers in manager_test.go test

### DIFF
--- a/watchdog/watcher/manager_test.go
+++ b/watchdog/watcher/manager_test.go
@@ -47,24 +47,33 @@ func TestWatchdogWatcherManagerWatch(t *testing.T) {
 
 	// primary
 	port, _ := strconv.Atoi(testutils.MongodbPrimaryPort)
-	mongod := &replset.Mongod{
+	assert.NoError(t, testWatchRs.UpdateMember(&replset.Mongod{
 		Host:    testutils.MongodbHost,
 		Port:    port,
 		Task:    apiTask,
 		PodName: t.Name(),
-	}
-	assert.NoError(t, testWatchRs.UpdateMember(mongod))
+	}))
 
 	assert.Nil(t, testManager.Get(testWatchRsService, "does-not-exist"), ".Get() returned data for non-existing watcher")
 	assert.False(t, testManager.HasWatcher(testWatchRsService, testutils.MongodbReplsetName))
 
 	// secondary1
-	mongod.Port, _ = strconv.Atoi(testutils.MongodbSecondary1Port)
-	assert.NoError(t, testWatchRs.UpdateMember(mongod))
+	port, _ = strconv.Atoi(testutils.MongodbSecondary1Port)
+	assert.NoError(t, testWatchRs.UpdateMember(&replset.Mongod{
+		Host:    testutils.MongodbHost,
+		Port:    port,
+		Task:    apiTask,
+		PodName: t.Name(),
+	}))
 
 	// secondary2
-	mongod.Port, _ = strconv.Atoi(testutils.MongodbSecondary2Port)
-	assert.NoError(t, testWatchRs.UpdateMember(mongod))
+	port, _ = strconv.Atoi(testutils.MongodbSecondary2Port)
+	assert.NoError(t, testWatchRs.UpdateMember(&replset.Mongod{
+		Host:    testutils.MongodbHost,
+		Port:    port,
+		Task:    apiTask,
+		PodName: t.Name(),
+	}))
 
 	tries := 0
 	for tries < 20 {
@@ -107,13 +116,12 @@ func TestWatchdogWatcherManagerWatch(t *testing.T) {
 	apiTaskState2.On("String").Return("OK")
 	apiTask2.On("State").Return(apiTaskState2)
 
-	mongod2 := &replset.Mongod{
+	assert.NoError(t, testWatchRs2.UpdateMember(&replset.Mongod{
 		Host:    testutils.MongodbHost,
 		Port:    port,
 		Task:    apiTask2,
 		PodName: t.Name() + "2",
-	}
-	assert.NoError(t, testWatchRs2.UpdateMember(mongod2))
+	}))
 
 	tries = 0
 	for tries < 20 {


### PR DESCRIPTION
1. Create new &replset.Mongod{} struct for each mock-member in test. This resolves all hosts being the last-changed host:port.